### PR TITLE
Correct type on encoding and decoding Message on queue

### DIFF
--- a/src/Transport/Queue.php
+++ b/src/Transport/Queue.php
@@ -168,7 +168,7 @@ class Queue
      */
     private function encodeMessage(Message $message): string
     {
-        return base64_encode(serialize($message));
+        return base64_encode(serialize($message->getBody()));
     }
 
     /**
@@ -179,6 +179,6 @@ class Queue
      */
     private function decodeMessage(string $message): Message
     {
-        return unserialize(base64_decode($message));
+        return new Message(base64_decode($message));
     }
 }


### PR DESCRIPTION
The encoding of message body fail as it tries to serialize the full Message object, but we only want the message body.

The encoded message was incorrectly returned as a string when a Message was expected. The (not needed) unserialization there also caused a failure.

This fix made the transport work for me, so I hope it can be accepted.
