### PR TITLE
Add missing return type in MessengerAzureQueueTransportExtension

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0",
-        "symfony/var-dumper": "^4.3|^5.0"
+        "symfony/var-dumper": "^4.3|^5.0|^6.0"
     },
     "scripts": {
         "test": "phpunit tests --testdox"

--- a/src/DependencyInjection/MessengerAzureQueueTransportExtension.php
+++ b/src/DependencyInjection/MessengerAzureQueueTransportExtension.php
@@ -15,7 +15,7 @@ class MessengerAzureQueueTransportExtension extends Extension
     /**
      * @inheritDoc
      */
-    public function load(array $configs, ContainerBuilder $container)
+    public function load(array $configs, ContainerBuilder $container): void
     {
         $loader = new YamlFileLoader(
             $container,


### PR DESCRIPTION
Fix compatibility with future Symfony versions

<img width="989" alt="Screenshot 2023-09-28 at 14 53 16" src="https://github.com/alexandrubau/messenger-azure-queue-transport/assets/438308/016fb2a8-fb6e-4cc6-93fb-350af0566dc7">
