### PR TITLE
Fix encode message

### DIFF
--- a/src/Transport/Queue.php
+++ b/src/Transport/Queue.php
@@ -168,7 +168,7 @@ class Queue
      */
     private function encodeMessage(Message $message): string
     {
-        return base64_encode(serialize($message->getBody()));
+        return base64_encode($message->getBody());
     }
 
     /**


### PR DESCRIPTION
The encoding / decoding was changed in #12 and a bug was introduced. The body is serialized on encoding, but not deserialized on decoding. This PR fixes only this issue.

The call to `serialize()` is not required as the `Message::getBody()` returns string.

Another issue is that the headers are lost due to the change in #12. @alexandrubau should this be left as is? I'm not sure what was the issue with the case of #12 as there are no details about it.