### PR TITLE
Add queue statistic support

### DIFF
--- a/src/Transport/Queue.php
+++ b/src/Transport/Queue.php
@@ -117,6 +117,16 @@ class Queue
     }
 
     /**
+     * Retrieves the message count.
+     *
+     * @return int
+     */
+    public function getMessageCount(): int
+    {
+        return $this->client->getQueueMetadata($this->getOption('queue_name'))->getApproximateMessageCount();
+    }
+
+    /**
      * Creates Azure Storage Queue client.
      *
      * @return QueueRestProxy

--- a/src/Transport/QueueTransport.php
+++ b/src/Transport/QueueTransport.php
@@ -3,13 +3,14 @@
 namespace Abau\MessengerAzureQueueTransport\Transport;
 
 use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Transport\Receiver\MessageCountAwareInterface;
 use Symfony\Component\Messenger\Transport\TransportInterface;
 use Symfony\Component\Messenger\Transport\Serialization\SerializerInterface;
 
 /**
  * Class QueueTransport
  */
-class QueueTransport implements TransportInterface
+class QueueTransport implements TransportInterface, MessageCountAwareInterface
 {
     /**
      * @var string
@@ -89,6 +90,14 @@ class QueueTransport implements TransportInterface
     public function send(Envelope $envelope): Envelope
     {
         return $this->getSender()->send($envelope);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getMessageCount(): int
+    {
+        return $this->getQueue()->getMessageCount();
     }
 
     /**


### PR DESCRIPTION
Added support to retrieve queue message count when running the `bin/console messenger:stats` command.